### PR TITLE
[not meant to merge directly] PWS Platform changes to conversions

### DIFF
--- a/Convert/build.gradle
+++ b/Convert/build.gradle
@@ -33,7 +33,13 @@ dependencies
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.2'
     compile 'com.squareup.okhttp:okhttp:2.7.5'
     compile 'com.google.code.gson:gson:2.6.2'
-    compile project(':wavefront-java-sdk')
+    compile 'org.threeten:threetenbp:1.4.0'
+    compile group: 'io.swagger.core.v3', name: 'swagger-annotations', version: '2.1.0'
+    compile group: 'io.swagger.codegen.v3', name: 'swagger-codegen-generators', version: '1.0.14'
+    compile group: 'javax.annotation', name: 'javax.annotation-api', version: '1.2'
+    compile group: 'com.squareup.okhttp', name: 'logging-interceptor', version: '2.7.5'
+    compile group: 'io.gsonfire', name: 'gson-fire', version: '1.8.3'
+    compile group: 'com.wavefront', name: 'wavefront-sdk-java', version: '1.15'
     compile 'junit:junit:4.12'
 }
 

--- a/Convert/build.sh
+++ b/Convert/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+pushd swagger
+./generate.sh
+popd
+
+mv swagger/src/main src/main
+mv swagger/src/test src/test

--- a/Convert/datadog-name-processor.yaml
+++ b/Convert/datadog-name-processor.yaml
@@ -34,6 +34,10 @@ rules:
       match   : '^.*\.Capacity[a-zA-Z]*Memory$'
       search  : '^(.*\.Capacity[a-zA-Z]*Memory)$'
       replace  : '$1.MiB'
+    - rule    : system.healthy gets ".b"
+      match   : '^.*\.system.healthy$'
+      search  : '^(.*\.system.healthy)$'
+      replace  : '$1.b'
 
 #    - rule    : origin goes away
 #      match   : '^.*origin.*$'

--- a/Convert/datadog-name-processor.yaml
+++ b/Convert/datadog-name-processor.yaml
@@ -25,3 +25,17 @@ rules:
       search  : 'mysql.galera.wsrep_cluster_size'
       replace : 'mysql.galera.wsrep_cluster_size'
 
+    - rule    : datadog.nozzle goes away
+      match   : '^datadog\.nozzle\..*$'
+      search  : '^datadog\.nozzle\.(.*)$'
+      replace  : 'pws-prod-test.$1'
+
+    - rule    : CapacityRemaining gets MiB
+      match   : '^.*\.Capacity[a-zA-Z]*Memory$'
+      search  : '^(.*\.Capacity[a-zA-Z]*Memory)$'
+      replace  : '$1.MiB'
+
+#    - rule    : origin goes away
+#      match   : '^.*origin.*$'
+#      search   : '^.*origin.*$'
+#      replace  : 'found.origin'

--- a/Convert/datadog.properties
+++ b/Convert/datadog.properties
@@ -4,9 +4,9 @@
 datadog.underscoreReplace=.
 datadog.dropTags=role,stackname,stack
 
-convert.converter=com.wavefront.labs.convert.converter.datadog.DatadogConverter
-convert.writer=com.wavefront.labs.convert.writer.FolderWriter
+convert.converter=com.wavefront.labs.convert.converter.datadog.DatadogConverter2
 convert.expressionBuilder=com.wavefront.labs.convert.converter.datadog.DatadogExpressionBuilder
+convert.writer=com.wavefront.labs.convert.writer.FolderWriter
 convert.name.processor.file=datadog-name-processor.yaml
 
 convert.writer.tags=wf-converted

--- a/Convert/src/com/wavefront/labs/convert/Convert.java
+++ b/Convert/src/com/wavefront/labs/convert/Convert.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -38,7 +39,7 @@ public class Convert {
 
 			doWrite(models);
 
-		} catch (IOException | InstantiationException | ClassNotFoundException | IllegalAccessException e) {
+		} catch (IOException | InstantiationException | ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			logger.error("Fatal error in start.", e);
 		}
 
@@ -46,10 +47,10 @@ public class Convert {
 		logger.error(com.wavefront.labs.convert.utils.Tracker.map);
 	}
 
-	private List doConvert(String[] args) throws ClassNotFoundException, IllegalAccessException, InstantiationException, IOException {
+	private List doConvert(String[] args) throws ClassNotFoundException, IllegalAccessException, InstantiationException, IOException, NoSuchMethodException, InvocationTargetException {
 		logger.info("Start Conversion");
 
-		Converter converter = (Converter) Class.forName(properties.getProperty("convert.converter")).newInstance();
+		Converter converter = (Converter) Class.forName(properties.getProperty("convert.converter")).getDeclaredConstructor().newInstance();
 		converter.init(properties);
 
 		String filename = null;
@@ -83,11 +84,11 @@ public class Convert {
 		return converter.convert();
 	}
 
-	private void doWrite(List models) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+	private void doWrite(List models) throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 		logger.info("Start Writing");
 
 		String generatorName = properties.getProperty("convert.writer", "com.wavefront.labs.convert.writer.WavefrontPublisher");
-		Writer writer = (Writer) Class.forName(generatorName).newInstance();
+		Writer writer = (Writer) Class.forName(generatorName).getDeclaredConstructor().newInstance();
 		writer.init(properties);
 
 		// tags can be separated by whitespace, comma, or semi-colon

--- a/Convert/src/com/wavefront/labs/convert/DefaultExpressionBuilder.java
+++ b/Convert/src/com/wavefront/labs/convert/DefaultExpressionBuilder.java
@@ -20,7 +20,7 @@ public class DefaultExpressionBuilder implements ExpressionBuilder {
 
 	protected Properties properties;
 
-	private NameProcessor nameProcessor;
+	protected NameProcessor nameProcessor;
 
 	@Override
 	public void init(Properties properties) {

--- a/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogExpressionBuilder.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogExpressionBuilder.java
@@ -91,10 +91,23 @@ public class DatadogExpressionBuilder extends DefaultExpressionBuilder {
 		variablesMap = new HashMap();
 	}
 
-	@Override
-	public String buildMetricName(String orig) {
+
+	public String buildMetricName(DatadogQuery datadogQuery) {
+		String orig = datadogQuery.getMetric();
+		List<String> scopes = datadogQuery.getScopes();
+		if (scopes != null && scopes.size() > 0) {
+			for (String scope : scopes) {
+				String[] scopeParts = scope.split(":");
+				if (scopeParts.length > 1 && scopeParts[0].equals("origin")) {
+					String origin = scopeParts[1];
+					String matcher = "^datadog\\.nozzle\\.(.*)$";
+					String replace = "datadog.nozzle." + origin + ".$1";
+					orig = orig.replaceAll(matcher,replace);
+				}
+			}
+		}
 		String metricName = buildName(orig, "metric");
-		metricName = metricName.replaceAll("_", underscoreReplace);
+		//metricName = metricName.replaceAll("_", underscoreReplace);
 		return super.buildMetricName(metricName);
 	}
 
@@ -188,7 +201,7 @@ public class DatadogExpressionBuilder extends DefaultExpressionBuilder {
 
 		String query = datadogQuery.getNumeral();
 		if (datadogQuery.getMetric() != null && !"".equals(datadogQuery.getMetric())) {
-			query = "ts(\"" + buildMetricName(datadogQuery.getMetric()) + "\"";
+			query = "ts(\"" + buildMetricName(datadogQuery) + "\"";
 
 			List<String> scopes = datadogQuery.getScopes();
 			if (scopes != null && scopes.size() > 0) {

--- a/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogTimeboardConverter.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogTimeboardConverter.java
@@ -208,7 +208,6 @@ public class DatadogTimeboardConverter extends AbstractDatadogConverter {
 		//dashboardParameterValue.setDynamicFieldType(DashboardParameterValue.DynamicFieldTypeEnum.TAG_KEY);
 		//dashboardParameterValue.setTagKey(variable.getValue());
 		//dashboardParameterValue.setQueryValue("ts(query.filter)");
-		dashboardParameterValue.setValue("");
 
 		return dashboardParameterValue;
 	}

--- a/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogTimeboardConverter2.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/datadog/DatadogTimeboardConverter2.java
@@ -211,7 +211,6 @@ public class DatadogTimeboardConverter2 extends AbstractDatadogConverter {
 		//dashboardParameterValue.setDynamicFieldType(DashboardParameterValue.DynamicFieldTypeEnum.TAG_KEY);
 		//dashboardParameterValue.setTagKey(variable.getValue());
 		//dashboardParameterValue.setQueryValue("ts(query.filter)");
-		dashboardParameterValue.setValue("");
 
 		return dashboardParameterValue;
 	}

--- a/Convert/src/com/wavefront/labs/convert/converter/datadog/models/DatadogGraphDefinition2.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/datadog/models/DatadogGraphDefinition2.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.util.List;
 
-@JsonIgnoreProperties({"autoscale", "status", "markers", "style", "group", "no_metric_hosts", "scope", "no_group_hosts", "notes", "show_legend", "legend_size", "text_align", "custom_unit", "size_by", "tick_pos", "color_by_groups", "node_type", "show_tick", "compare_to", "xaxis", "color_by", "events", "tick_edge", "q", "group_by", "content", "font_size", "background_color", "precision", "layout_type", "title_size", "title_align", "color", "viz_type", "url", "time", "text", "alert_id", "tags_execution", "sizing", "query", "sort", "tags", "event_size", "margin", "count", "check", "hide_zero_counts", "grouping", "unit", "start", "color_preference", "display_format"})
+@JsonIgnoreProperties({"show_last_triggered","autoscale", "status", "markers", "style", "group", "no_metric_hosts", "scope", "no_group_hosts", "notes", "show_legend", "legend_size", "text_align", "custom_unit", "size_by", "tick_pos", "color_by_groups", "node_type", "show_tick", "compare_to", "xaxis", "color_by", "events", "tick_edge", "q", "group_by", "content", "font_size", "background_color", "precision", "layout_type", "title_size", "title_align", "color", "viz_type", "url", "time", "text", "alert_id", "tags_execution", "sizing", "query", "sort", "tags", "event_size", "margin", "count", "check", "hide_zero_counts", "grouping", "unit", "start", "color_preference", "display_format"})
 public class DatadogGraphDefinition2 {
 
 	private String type;

--- a/Convert/src/com/wavefront/labs/convert/converter/grafana/GrafanaConverter.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/grafana/GrafanaConverter.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -38,8 +39,8 @@ public class GrafanaConverter implements Converter {
 		String expressionBuilderClass = properties.getProperty("convert.expressionBuilder", "");
 		if (!expressionBuilderClass.equals("")) {
 			try {
-				expressionBuilder = (ExpressionBuilder) Class.forName(expressionBuilderClass).newInstance();
-			} catch (IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+				expressionBuilder = (ExpressionBuilder) Class.forName(expressionBuilderClass).getDeclaredConstructor().newInstance();
+			} catch (IllegalAccessException | InstantiationException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
 				logger.error("Could not create instance of: " + expressionBuilderClass, e);
 				expressionBuilder = new SimpleExpressionBuilder();
 			}

--- a/Convert/src/com/wavefront/labs/convert/converter/grafana/GrafanaConverterHelper.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/grafana/GrafanaConverterHelper.java
@@ -262,7 +262,17 @@ public class GrafanaConverterHelper {
 				chartSourceQuery.setDisabled(target.isHide());
 				chartSourceQuery.setName(target.getRefId());
 
-				String query = target.getTargetFull() != null && !target.getTargetFull().equals("") ? target.getTargetFull() : target.getTarget();
+				String query;
+				if (target.getExpr() != null && !target.getExpr().equals("")) {
+					query = target.getExpr();
+				} else if (target.getTargetFull() != null && !target.getTargetFull().equals("")) {
+					query = target.getTargetFull();
+				} else if (target.getTarget() != null && !target.getTarget().equals("")){
+					query = target.getTarget();
+				} else {
+					continue;
+				}
+
 				chartSourceQuery.setQuery(expressionBuilder.buildExpression(query));
 
 				chartSourceQueries.add(chartSourceQuery);

--- a/Convert/src/com/wavefront/labs/convert/converter/grafana/model/GrafanaPanelTarget.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/grafana/model/GrafanaPanelTarget.java
@@ -10,6 +10,7 @@ public class GrafanaPanelTarget {
 	private String refId;
 	private String target;
 	private String targetFull;
+	private String expr;
 	private boolean textEditor;
 
 	public boolean isHide() {
@@ -50,6 +51,14 @@ public class GrafanaPanelTarget {
 
 	public void setTargetFull(String targetFull) {
 		this.targetFull = targetFull;
+	}
+
+	public String getExpr() {
+		return expr;
+	}
+
+	public void setExpr(String expr) {
+		this.expr = expr;
 	}
 
 	public boolean isTextEditor() {

--- a/Convert/src/com/wavefront/labs/convert/converter/rrd/models/Def.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/rrd/models/Def.java
@@ -6,6 +6,8 @@ import com.wavefront.labs.convert.converter.rrd.RRDExpressionBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.lang.reflect.InvocationTargetException;
+
 public class Def extends Definition {
 	private static final Logger logger = LogManager.getLogger(Def.class);
 
@@ -35,8 +37,8 @@ public class Def extends Definition {
 		String expressionBuilderClass = context.getProperties().getProperty("convert.expressionBuilder", "");
 		if (!expressionBuilderClass.equals("")) {
 			try {
-				expressionBuilder = (ExpressionBuilder) Class.forName(expressionBuilderClass).newInstance();
-			} catch (IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+				expressionBuilder = (ExpressionBuilder) Class.forName(expressionBuilderClass).getDeclaredConstructor().newInstance();
+			} catch (IllegalAccessException | InstantiationException | ClassNotFoundException | NoSuchMethodException | InvocationTargetException e) {
 				logger.error("Could not create instance of: " + expressionBuilderClass, e);
 				expressionBuilder = new RRDExpressionBuilder();
 			}

--- a/Convert/src/com/wavefront/labs/convert/converter/rrd/models/VDef.java
+++ b/Convert/src/com/wavefront/labs/convert/converter/rrd/models/VDef.java
@@ -12,6 +12,7 @@ import java.util.function.Function;
 public class VDef extends Definition {
 
 	private static HashMap<String, Function<Deque<String>, String>> functionMap = new HashMap();
+
 	static {
 		functionMap.put("MAXIMUM", NotSupported::warning);
 		functionMap.put("MINIMUM", NotSupported::warning);
@@ -27,7 +28,7 @@ public class VDef extends Definition {
 		functionMap.put("LSLCORREL", NotSupported::warning);
 	}
 
-	public VDef (String line) {
+	public VDef(String line) {
 		super(line);
 	}
 


### PR DESCRIPTION
@puckpuck Here are the changes my teammates (mostly @xtreme-jesse-malone) made to get this functional for us. I suspect many/most of these changes are things you will **not** want to take.

He also dropped these comments:

> General Dashboard migration Prerequisites:
> 
> On the datadog dashboard:
> 
> - Remove text boxes
> - all job metrics must have origin
> - `bosh.healthmonitor.*` must be converted to `datadog.nozzle.* {origin:healthmonitor}`
> - _Wavefront considerations:_
>   - `*.system.healthy needs .b` . This type of change can be added to the `datadog-name-processor.yml` file of the converter